### PR TITLE
Ensure do_as resets the old user as current when an error is raised

### DIFF
--- a/lib/sentient_user.rb
+++ b/lib/sentient_user.rb
@@ -22,9 +22,14 @@ module SentientUser
       
       def self.do_as(user, &block)
         old_user = self.current
-        self.current = user
-        response = block.call unless block.nil?
-        self.current = old_user
+
+        begin
+          self.current = user
+          response = block.call unless block.nil?
+        ensure
+          self.current = old_user
+        end
+
         response
       end
     }

--- a/test/test_sentient_user.rb
+++ b/test/test_sentient_user.rb
@@ -26,4 +26,24 @@ class TestSentientUser < Test::Unit::TestCase
   should "allow subclasses of user to be assigned to user.current" do
     User.current = AnonymousUser.new
   end
+
+  should "allow execution of a block as a specified user" do
+    p, p2 = Person.new, Person.new
+    p.make_current
+    Person.do_as(p2) { assert_equal Person.current, p2 }
+  end
+
+  should "should reset the original user after executing a block as a specified user" do
+    p, p2 = Person.new, Person.new
+    p.make_current
+
+    Person.do_as(p2) { }
+    assert_equal Person.current, p
+
+    begin
+      Person.do_as(p2) { raise "error" }
+    rescue
+      assert_equal Person.current, p
+    end
+  end
 end


### PR DESCRIPTION
Hey David. I made a very minor change to wrap part of the do_as method in a begin/rescue block to ensure the old user is reset as current if the block ends up raising an error.
