### PR TITLE
Upgrade to Rails 5 - before_filter > before_action

### DIFF
--- a/lib/sentient_user.rb
+++ b/lib/sentient_user.rb
@@ -39,7 +39,7 @@ end
 module SentientController
   def self.included(base)
     base.class_eval {
-      before_filter do |c|
+      before_action do |c|
         User.current = c.send(:current_user)
       end
     }


### PR DESCRIPTION
Rails 5 is deprecating `before_filter` to `before_action`
