### PR TITLE
Clear User.current after controller actions

### DIFF
--- a/lib/sentient_user.rb
+++ b/lib/sentient_user.rb
@@ -42,6 +42,10 @@ module SentientController
       before_action do |c|
         User.current = c.send(:current_user)
       end
+
+      after_action do |c|
+        User.current = nil
+      end
     }
   end
 end


### PR DESCRIPTION
### Tests suites might get flaky when `User.current` is not cleanup after tests
In the "normal" Rails request/response lifecycle it's not needed to clear `User.current` after a request has been processed (since it will reset on each new request). However, in tests this not the case. If we have an integration/system test that sets `User.current` and then afterwards we run a non-controller test (e.g. a background job test etc) we get unexpected behavior.
